### PR TITLE
Fix notify.sh DM fallback and handoff over-summarization

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -258,11 +258,15 @@ If `$ARGUMENTS` has no clear recipient, show a picker using AskUserQuestion:
 
 If no recipient detected or user picks "General", the handoff is for the team or future self.
 
-## Step 2: Summarize the session
+## Step 2: Summarize for the recipient
 
-Analyze the conversation context to produce:
+Analyze the conversation context. **Scope to the focal topic** — if the conversation has a clear focal finding, bug, artifact, or decision, summarize *that*, not the entire session. Preserve concrete details: line numbers, file paths, error messages, proposed fixes. The recipient needs to act on this without re-reading the conversation.
 
-1. **Session summary** — 2-3 sentences on what was accomplished
+If the session covered many topics with no clear focus, summarize broadly.
+
+Produce:
+
+1. **Summary** — 2-3 sentences scoped to the focal topic (or session if broad)
 2. **Key decisions** — any decisions made with rationale
 3. **Current state** — what's working, in progress, blocked
 4. **Open threads** — unfinished items with enough context to pick up

--- a/bin/notify.sh
+++ b/bin/notify.sh
@@ -42,7 +42,11 @@ if [ -n "$API_URL" ] && [ -n "$API_KEY" ]; then
     else
       local detail
       detail=$(echo "$response" | jq -r '.detail // .status // "unknown error"')
-      echo "Failed: $detail"
+      if echo "$detail" | grep -qi "forbidden\|can't initiate\|bot was blocked"; then
+        echo "Failed: DM not available. Tell $name to message the Egregore bot first (/start)."
+      else
+        echo "Failed: $detail"
+      fi
       bash "$SCRIPT_DIR/bin/telemetry.sh" emit "notification" \
         '{"type":"send","status":"failed"}' 2>/dev/null &
     fi
@@ -90,7 +94,13 @@ if [ -n "$API_URL" ] && [ -n "$API_KEY" ]; then
     send)
       recipient="${2:?Usage: notify.sh send <name> <message>}"
       message="${3:?Usage: notify.sh send <name> <message>}"
-      send_to_person "$recipient" "$message"
+      result=$(send_to_person "$recipient" "$message")
+      if [[ "$result" == Failed* ]]; then
+        send_to_group "@${recipient}: ${message}"
+        echo "DM failed, sent to group instead. ${result}"
+      else
+        echo "$result"
+      fi
       ;;
     group)
       message="${2:?Usage: notify.sh group <message>}"
@@ -107,7 +117,7 @@ if [ -n "$API_URL" ] && [ -n "$API_KEY" ]; then
       echo "Usage: notify.sh <command>"
       echo ""
       echo "Commands:"
-      echo "  send <name> <message>   Send to a person (DM or group fallback)"
+      echo "  send <name> <message>   Send DM to a person (auto-fallback to group on failure)"
       echo "  group <message>         Send to the group chat"
       echo "  file <path> [caption]   Send a file to the group chat"
       echo "  test                    Test connection"


### PR DESCRIPTION
## Summary

- **notify.sh**: DM failures now auto-fallback to group chat instead of silently failing. Telegram "Forbidden"/"can't initiate" errors return actionable guidance (tell the user to `/start` the bot).
- **handoff.md**: Step 2 now scopes summaries to the focal topic when one exists, preserving concrete details (line numbers, file paths, proposed fixes) instead of always summarizing the full session.

## Context

From bartu's audit findings:
- `memory/knowledge/findings/2026-02-17-notify-dm-failure-no-fallback.md`
- `memory/knowledge/findings/2026-02-17-handoff-over-summarizes-targeted-bugs.md`

## Test plan

- [ ] Run `bash bin/notify.sh send <user-without-start> "test"` — should fallback to group and show actionable error
- [ ] Run `/handoff <specific-bug> to <person>` after discussing a focused topic — summary should scope to that topic, not the full session

🤖 Generated with [Claude Code](https://claude.com/claude-code)